### PR TITLE
Unhandled exception from tlsext_servername_callback generates SIGSEGV.

### DIFF
--- a/OpenSSL/ssl/context.c
+++ b/OpenSSL/ssl/context.c
@@ -267,7 +267,14 @@ global_tlsext_servername_callback(const SSL *ssl, int *alert, void *arg) {
     argv = Py_BuildValue("(O)", (PyObject *)conn);
     ret = PyEval_CallObject(conn->context->tlsext_servername_callback, argv);
     Py_DECREF(argv);
-    Py_DECREF(ret);
+    if (ret == NULL) {
+        /*
+         * XXX - This should be reported somehow. -exarkun
+         */
+        PyErr_Clear();
+    } else {
+        Py_DECREF(ret);
+    }
 
     /*
      * This function is returning into OpenSSL.  Release the GIL again.


### PR DESCRIPTION
If the function specified by set_tlsext_servername_callback generates an exception, this code will generate a SEGFAULT on context.c:270.

This changes the handling of the return value for this function to remain consistent with the other callbacks in this file: if an exception is returned, silently absorb the error and do not call Py_DECREF(ret).

Launchpad bug added here: https://bugs.launchpad.net/pyopenssl/+bug/1266121

Documenting this on github to increase chance that people will find it through Google searches.
